### PR TITLE
Исправил ошибку в HelperWidget

### DIFF
--- a/lib/widget/HelperWidget.php
+++ b/lib/widget/HelperWidget.php
@@ -232,7 +232,7 @@ abstract class HelperWidget
      */
     public function showBasicEditField($isPKField)
     {
-        if ($this->getSettings('HIDE_WHEN_CREATE') AND !isset($this->data['ID'])) {
+        if ($this->getSettings('HIDE_WHEN_CREATE') AND !isset($this->data[$this->helper->pk()])) {
             return;
         }
 
@@ -297,11 +297,11 @@ abstract class HelperWidget
     {
         $rsEntityData = null;
         $values = array();
-        if (!empty($this->data['ID'])) {
+        if (!empty($this->data[$this->helper->pk()])) {
             $entityName = $this->entityName;
             $rsEntityData = $entityName::getList(array(
                 'select' => array('REFERENCE_' => $this->getCode() . '.*'),
-                'filter' => array('=ID' => $this->data['ID'])
+                'filter' => array('=ID' => $this->data[$this->helper->pk()])
             ));
 
             if ($rsEntityData) {
@@ -814,7 +814,7 @@ abstract class HelperWidget
      */
     protected function getEditableListInputName()
     {
-        $id = $this->data['ID'];
+        $id = $this->data[$this->helper->pk()];
 
         return 'FIELDS[' . $id . '][' . $this->getCode() . ']';
     }


### PR DESCRIPTION
В некоторых местах явно задан primary key равным 'ID'. Это не корректно, так как у некоторых моделей он может быть переопределён с помощью метода pk(). Поэтому вместо $this->data['ID'] необходимо использовать $this->data[$this->helper->pk()].

Без этого исправления у меня некорректно работает групповое редактирование записей в таблице, если у модели pk равен id, а не ID.